### PR TITLE
Version fix: phoenix-common to work with rev ef053c5

### DIFF
--- a/programs/drift/Cargo.toml
+++ b/programs/drift/Cargo.toml
@@ -32,7 +32,7 @@ arrayref = "0.3.6"
 base64 = "0.13.0"
 serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "85b4f14", version = "0.5.6", features = ["no-entrypoint"] }
 enumflags2 = "0.6.4"
-phoenix = { git = "https://github.com/Ellipsis-Labs/phoenix-v1", branch = "crate", version = "0.1.0", package = "phoenix-common" }
+phoenix = { git = "https://github.com/Ellipsis-Labs/phoenix-v1", rev = "ef053c5", version = "0.1.0", package = "phoenix-common", features = ["no-entrypoint"] }
 solana-security-txt = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
as this revision is used in marinade-snapshot-etl and as the revision was removed from driv protocol branch crate and it's available only in repository but not at branch anymore